### PR TITLE
feat: property, vehicle and user types and models added

### DIFF
--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -1,0 +1,3 @@
+export * from "./property.model.js";
+export * from "./user.model.js";
+export * from "./vehicle.model.js";

--- a/src/api/models/property.model.ts
+++ b/src/api/models/property.model.ts
@@ -1,0 +1,68 @@
+import type { IProperty } from "@/types/property.type.js";
+import mongoose, { Schema } from "mongoose";
+
+const propertySchema = new Schema<IProperty>(
+  {
+    name: {
+      type: String,
+      required: [true, "El nombre de la propiedad es obligatorio"],
+      trim: true,
+      minLength: [3, "El nombre debe tener al menos 3 caracteres"],
+      maxLength: [100, "El nombre no puede exceder de los 100 caracteres"],
+    },
+    type: {
+      type: String,
+      required: [true, "El tipo de propiedad es obligatorio"],
+      trim: true,
+      enum: {
+        values: ["apartment", "rural_house", "flat", "studio", "other"],
+        message: "Tipo de propiedad inválido",
+      },
+    },
+    address: {
+      type: String,
+      required: [true, "La dirección es obligatoria"],
+      trim: true,
+      minLength: [5, "La dirección debe tener al menos 5 caracteres"],
+      maxLength: [200, "La dirección no puede exceder los 200 caracteres"],
+    },
+    status: {
+      type: String,
+      required: [true, "El estado es obligatorio"],
+      enum: {
+        values: ["available", "rented", "maintenance"],
+        message: "Estado no válido",
+      },
+    },
+    monthlyRent: {
+      type: Number,
+      required: [true, "La renta mensual es obligatoria"],
+      min: [0, "La renta mensual no puede ser negativa"],
+    },
+    expenses: {
+      type: Number,
+      required: [true, "Los gastos son obligatorios"],
+      min: [0, "Los gastos no pueden ser negativos"],
+    },
+    paid: { type: Boolean, required: true, default: false },
+    image: { type: String, required: [true, "La imagen es obligatoria"] },
+    owner: {
+      type: Schema.Types.ObjectId,
+      required: [true, "El propietario es obligatorio"],
+      ref: "users",
+    },
+  },
+  { timestamps: true }
+);
+
+propertySchema.index(
+  { name: 1, owner: 1 },
+  { unique: true, collation: { locale: "es", strength: 2 } }
+);
+
+propertySchema.index(
+  { address: 1, owner: 1 },
+  { unique: true, collation: { locale: "es", strength: 2 } }
+);
+
+export const Property = mongoose.model("properties", propertySchema, "properties");

--- a/src/api/models/user.model.ts
+++ b/src/api/models/user.model.ts
@@ -1,0 +1,65 @@
+import type { IUser } from "@/types/user.type.js";
+import mongoose, { Schema } from "mongoose";
+import bcrypt from "bcrypt";
+
+const userSchema = new Schema<IUser>(
+  {
+    name: {
+      type: String,
+      required: [true, "El nombre es obligatorio"],
+      trim: true,
+      unique: true,
+      minLength: [3, "El nombre debe tener al menos 3 caracteres"],
+      maxLength: [20, "El nombre no puede exceder de 20 caracteres"],
+    },
+    email: {
+      type: String,
+      required: [true, "El email es obligatorio"],
+      trim: true,
+      unique: true,
+      match: [/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/, "Formato de email inválido"],
+    },
+    password: {
+      type: String,
+      required: [true, "La contraseña es obligatoria"],
+      minLength: [8, "La contraseña debe tener al menos 8 caracteres"],
+      maxLength: [128, "La contraseña no puede superar los 128 caracteres"],
+      select: false,
+    },
+    role: {
+      type: String,
+      required: true,
+      enum: {
+        values: ["user", "admin"],
+        message: "Rol no válido",
+      },
+      default: "user",
+    },
+    image: {
+      type: String,
+      required: [true, "La imagen es obligatoria"],
+      trim: true,
+    },
+    properties: [{ type: Schema.Types.ObjectId, ref: "properties" }],
+    vehicles: [{ type: Schema.Types.ObjectId, ref: "vehicles" }],
+  },
+  { timestamps: true }
+);
+
+userSchema.pre("save", async function (next) {
+  if (!this.isModified("password")) return next();
+
+  try {
+    const salt = await bcrypt.genSalt(12); 
+    this.password = await bcrypt.hash(this.password, salt);
+    next();
+  } catch (error) {
+    next(error as Error);
+  }
+});
+
+userSchema.methods.comparePassword = async function (candidatePassword: string): Promise<boolean> {
+  return await bcrypt.compare(candidatePassword, this.password);
+};
+
+export const User = mongoose.model("users", userSchema, "users");

--- a/src/api/models/vehicle.model.ts
+++ b/src/api/models/vehicle.model.ts
@@ -1,0 +1,57 @@
+import type { IVehicle } from "@/types/vehicle.type.js";
+import mongoose, { Schema } from "mongoose";
+
+const vehicleSchema = new Schema<IVehicle>(
+  {
+    name: {
+      type: String,
+      required: [true, "El nombre del vehículo  es obligatorio"],
+      trim: true,
+      minLength: [3, "El nombre debe tener al menos 3 caracteres"],
+      maxLength: [100, "El nombre no puede exceder de los 100 caracteres"],
+    },
+    type: {
+      type: String,
+      required: [true, "El tipo de vehículo es obligatorio"],
+      enum: {
+        values: ["car", "motorcycle", "truck", "van", "other"],
+        message: "Tipo del vehículo inválido",
+      },
+    },
+    plate: {
+      type: String,
+      required: [true, "La matrícula es obligatoria"],
+      trim: true,
+      unique: true,
+      match: [/^\d{4}[A-Z]{3}$/, "Formato de la matrícula inválido (ej: 1234ABC)"],
+    },
+    status: {
+      type: String,
+      required: [true, "El estado es obligatorio"],
+      enum: {
+        values: ["available", "rented", "maintenance"],
+        message: "Estado no válido",
+      },
+    },
+    dailyRent: {
+      type: Number,
+      required: [true, "La renta diaria es obligatoria"],
+      min: [0, "La renta diaria no puede ser negativa"],
+    },
+    expenses: {
+      type: Number,
+      required: [true, "Los gastos son obligatorios"],
+      min: [0, "Los gastos no pueden ser negativos"],
+    },
+    paid: { type: Boolean, required: true, default: false },
+    image: { type: String, required: [true, "La imagen es obligatoria"] },
+    owner: {
+      type: Schema.Types.ObjectId,
+      required: [true, "El propietario es obligatorio"],
+      ref: "users",
+    },
+  },
+  { timestamps: true }
+);
+
+export const Vehicle = mongoose.model("vehicles", vehicleSchema, "vehicles");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from "./property.type.js";
+export * from "./user.type.js";
+export * from "./vehicle.type.js";

--- a/src/types/property.type.ts
+++ b/src/types/property.type.ts
@@ -1,0 +1,17 @@
+import type { Document, Types } from "mongoose";
+
+export interface IProperty {
+  name: string;
+  type: "apartment" | "rural_house" | "flat" | "studio" | "other";
+  address: string;
+  status: "available" | "rented" | "maintenance";
+  monthlyRent: number;
+  expenses: number;
+  paid: boolean;
+  image: string;
+  owner: Types.ObjectId;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface PropertyDoc extends IProperty, Document {}

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -1,0 +1,15 @@
+import type { Document, Types } from "mongoose";
+
+export interface IUser {
+  name: string;
+  email: string;
+  password: string;
+  role: "user" | "admin";
+  image: string;
+  properties?: Types.ObjectId[];
+  vehicles?: Types.ObjectId[];
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface UserDoc extends IUser, Document {}

--- a/src/types/vehicle.type.ts
+++ b/src/types/vehicle.type.ts
@@ -1,0 +1,17 @@
+import type { Document, Types } from "mongoose";
+
+export interface IVehicle {
+  name: string;
+  type: "car" | "motorcycle" | "truck" | "van" | "other";
+  plate: string;
+  status: "available" | "rented" | "maintenance";
+  dailyRent: number;
+  expenses: number;
+  paid: boolean;
+  image: string;
+  owner: Types.ObjectId;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface VehicleDoc extends IVehicle, Document {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,21 @@
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+
+    // Path Aliases
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"],
+      "@api/*": ["api/*"],
+      "@config/*": ["config/*"],
+      "@controllers/*": ["api/controllers/*"],
+      "@middlewares/*": ["middlewares/*"],
+      "@models/*": ["api/models/*"],
+      "@routes/*": ["api/routes/*"],
+      "@types/*": ["types/*"],
+      "@utils/*": ["utils/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
# [FEAT] Add Property, Vehicle and User models and types

## Descripción
Este PR introduce los modelos y tipos TypeScript para las entidades principales del sistema:
- Propiedades (Properties)
- Vehículos (Vehicles)
- Usuarios (Users)

## Cambios realizados
- 🏠 **Property Model**:
  - Campos: name, type, address, status, monthlyRent, expenses, paid, image, owner
  - Validaciones completas con mensajes de error descriptivos
  - Índices únicos para name+owner y address+owner

- 🚗 **Vehicle Model**:
  - Campos: name, type, plate, status, dailyRent, expenses, paid, image, owner
  - Validación de formato para matrícula (ej: 1234ABC)
  - Plate como campo único

- 👤 **User Model**:
  - Campos: name, email, password, role, image, properties[], vehicles[]
  - Hash de contraseña con bcrypt (pre-save hook)
  - Método comparePassword para autenticación
  - Email y name como campos únicos

- 📦 **Types**:
  - Interfaces TypeScript para todas las entidades
  - Tipos específicos para valores enum (roles, estados, tipos)
  - Exportación centralizada desde src/types/index.ts

- ⚙️ **Config**:
  - Añadidos path aliases para imports (@/, @api/, @types/, etc.)

## Notas para revisión
1. Todos los modelos incluyen:
   - Validaciones completas con mensajes descriptivos
   - Campos requeridos marcados explícitamente
   - Timestamps automáticos
   - Referencias correctamente tipadas

2. La seguridad de usuarios incluye:
   - Password hashing con salt de 12 rondas
   - Campo password marcado como select: false
   - Longitud mínima/máxima de contraseña

3. Los tipos están correctamente extendidos de Document de Mongoose

## Pruebas realizadas
- [x] Validación de esquemas con datos correctos/incorrectos
- [x] Comprobación de índices únicos
- [x] Verificación de hooks (hash de password)
- [x] Tipos TypeScript comprobados

## Screenshots (si aplica)
N/A (cambios de backend)

## Issues relacionados
N/A (implementación inicial)